### PR TITLE
feat: add trending command

### DIFF
--- a/cogs/music/music.py
+++ b/cogs/music/music.py
@@ -198,3 +198,20 @@ class Music(commands.Cog):
             await ctx.send(embed=Embed().ok("Switched to the new voice channel!"))
         else:
             await ctx.send(embed=Embed().error("No need to change the voice channel!"))
+
+            
+    @app_commands.command(
+        name="trending", description="Phát một bài nhạc đang trending trên YouTube"
+    )
+    @ensure_voice
+    async def trending(self, interaction: discord.Interaction) -> None:
+        if not interaction.response.is_done():
+            await self.set_reply_timeout(interaction)
+        ctx = await self.bot.get_context(interaction)
+
+        if not await ensure_same_channel(ctx):
+            return
+
+        if interaction.guild_id:
+            audio = get_or_create_audio(self.bot, interaction.guild_id)
+            await audio.process_trending(ctx)


### PR DESCRIPTION
This pull request introduces functionality to play trending music videos from YouTube in a Discord bot. The changes span multiple files, adding new methods and commands to handle trending video retrieval and playback. Below is a summary of the most important changes.

### New functionality for playing trending music:

* **Added `process_trending` method in `cogs/music/controller.py`:** Implements the logic to fetch a trending music video, create a song object, clear the current queue, and play the song. Includes error handling and user feedback via Discord messages.
* **Added `trending` command in `cogs/music/music.py`:** Provides a Discord slash command to trigger the playback of a trending music video. Ensures the user is in the same voice channel before proceeding.

### YouTube service enhancements:

* **Added `get_trending_videos` method in `cogs/music/services/youtube_service.py`:** Retrieves a list of trending videos from YouTube based on category and region using `yt-dlp`. Includes error handling for extraction failures.
* **Added `get_trending_music_video` method in `cogs/music/services/youtube_service.py`:** Uses `get_trending_videos` to fetch and return the first trending music video for a specified region.

### Utility improvements:

* **Added `_format_duration` method in `cogs/music/controller.py`:** Formats video duration from seconds to a `MM:SS` string for user-friendly display.